### PR TITLE
Fix API key secret path

### DIFF
--- a/apphosting.yaml
+++ b/apphosting.yaml
@@ -2,7 +2,7 @@
 runConfig:
   maxInstances: 1
 environmentVariables:
-  GOOGLE_API_KEY: "secret:projects/cdigo-tu-start-inteligente/secrets/CODIGO_WEB_GOOGLE_API_KEY/versions/latest"
+  GOOGLE_API_KEY: "secret:projects/codigo-tu-start-inteligente/secrets/CODIGO_WEB_GOOGLE_API_KEY/versions/latest"
   NODE_ENV: "production"
   NEXT_PUBLIC_SUPABASE_URL: "https://itrklyodvrgowtanxvhn.supabase.co"
   NEXT_PUBLIC_SUPABASE_ANON_KEY: "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6Iml0cmtseW9kdnJnb3d0YW54dmhuIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NDcxNjgwNTUsImV4cCI6MjA2Mjc0NDA1NX0.0dF0l5zl6wSww2gz26ThQV3AAcxzaA96f2t6zpwD7pI"


### PR DESCRIPTION
## Summary
- correct the GOOGLE_API_KEY path to use **codigo-tu-start-inteligente**

## Testing
- `grep -n "codigo-tu-start-inteligente" apphosting.yaml`


------
https://chatgpt.com/codex/tasks/task_e_6841e4add340832ab4192880240b3d45