### PR TITLE
Fix comment about sidebar collapse state

### DIFF
--- a/src/components/layout/AppLayoutClient.tsx
+++ b/src/components/layout/AppLayoutClient.tsx
@@ -11,7 +11,7 @@ interface AppLayoutClientProps {
 }
 
 const AppLayoutClient: React.FC<AppLayoutClientProps> = ({ children }) => {
-  const [isCollapsed, setIsCollapsed] = useState(false); // Default to true (collapsed) or false based on preference
+  const [isCollapsed, setIsCollapsed] = useState(false); // Default is expanded (false). Set true to start collapsed if preferred.
   
   useEffect(() => {
     const checkMobile = () => {


### PR DESCRIPTION
## Summary
- correct the default collapse comment

## Testing
- `npm run lint` *(fails: prompts for config)*
- `npm run typecheck` *(fails: TS errors)*

------
https://chatgpt.com/codex/tasks/task_e_6841e4b0b940832a9ae3bce90bd7fd2f